### PR TITLE
fixed bad econtact phone bug in volunteer registration

### DIFF
--- a/register.php
+++ b/register.php
@@ -50,8 +50,7 @@
             $required = array(
                 'first-name', 'last-name', 'birthdate',
                 'address', 'city', 'state', 'zip', 
-                'email', 'phone', 'econtactPhone', 'econtactName',
-                'start-date', 'password',
+                'email', 'phone', 'start-date', 'password',
             );
             $errors = false;
             if (!wereRequiredFieldsSubmitted($args, $required)) {
@@ -111,19 +110,33 @@
                 echo 'bad contact method';
             }
 
-
-
-            $econtactName = $args['econtact-name'];
-            $econtactPhone = validateAndFilterPhoneNumber($args['econtact-phone']);
-            if (!$econtactPhone) {
-                $errors = true;
-                echo 'bad econtact phone';
+            /* Emergency Contact Information Section Data */
+            // Collect econtact name if provided, otherwise set it to the empty string
+            if (isset($args['econtact-name']) && !empty($args['econtact-name'])) {
+                $econtactName = $args['econtact-name'];
             }
-
-            //$econtactPhone = $args['econtact-phone'];
-    
-            $econtactRelation = $args['econtact-relation'];
-
+            else {
+                $econtactName = '';
+            }
+            // Collect and validate econtact phone if provided, otherwise set it to the empty string
+            if (isset($args['econtact-phone']) && !empty($args['econtact-phone'])) {
+                $econtactPhone = validateAndFilterPhoneNumber($args['econtact-phone']);
+                if (!$econtactPhone) {
+                    $errors = true;
+                    echo 'bad econtact phone';
+                }
+            }
+            else {
+                $econtactPhone = '';
+            }
+            // Collect econtact relation if provided, otherwise set it to the empty string
+            if (isset($args['econtact-relation']) && !empty($args['econtact-relation'])) {
+                $econtactRelation = $args['econtact-relation'];
+            }
+            else {
+                $econtactRelation = '';
+            }
+            
             $startDate = validateDate($args['start-date']);
             if (!$startDate) {
                 $errors = true;

--- a/registrationForm.php
+++ b/registrationForm.php
@@ -165,10 +165,10 @@ function buildSelect($name, $disabled=false, $selected=null) {
         <fieldset>
             <legend>Emergency Contact</legend>
             <p>Please provide us with someone to contact on your behalf in case of an emergency.</p>
-            <label for="econtact-name" ><em>* </em>Contact Name</label>
+            <label for="econtact-name" ><em> </em>Contact Name</label>
             <input type="text" id="econtact-name" name="econtact-name"  placeholder="Enter emergency contact name">
 
-            <label for="econtact-phone"><em>* </em>Contact Phone Number</label>
+            <label for="econtact-phone"><em> </em>Contact Phone Number</label>
             <input type="tel" id="econtact-phone" name="econtact-phone" pattern="\([0-9]{3}\) [0-9]{3}-[0-9]{4}"  placeholder="Enter emergency contact phone number. Ex. (555) 555-5555">
 
             <label for="econtact-name"><em> </em>Contact Relation to You</label>


### PR DESCRIPTION
in registration, the econtact phone number was being passed to the validateAndFilterPhoneNumber function, regardless of whether it was provided. Added checks for it before doing so.